### PR TITLE
Enhance performance by caching headers for on-demand requests!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ The FUC Website Project is an information portal for the Federación Universitar
 * **Consultation/Complaint Submission**: A system for users to submit queries and feedback.
 * **Historical Information**: An archive of the federation’s milestones and achievements.
 
+## Features
+
+- **Enhanced Performance**: Configured for optimal performance with Netlify CDN, using advanced caching headers (e.g., `Netlify-CDN-Cache-Control` and `Netlify-Vary`) to ensure fast content delivery.
+- **Server-Side Rendering (SSR)**: Pages are rendered on the server for improved SEO, faster initial load times, and better performance on low-powered devices.
+- **Incremental Static Regeneration (ISR)**: Combines the benefits of static generation with the ability to update content dynamically, ensuring both performance and freshness.
+- **Astro View Transitions**: Smooth transitions between pages enhance user experience (`just for stricly static pages`).
+- **Responsive Design**: Built with Tailwind CSS to ensure the site looks great on all devices.
+- **Interactive UI Components**: Powered by React for client-side interactions where needed.
+
+
 ## Technology Stack
 
 This project is built with:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,17 +6,13 @@ import netlify from '@astrojs/netlify';
 
 export default defineConfig({
   output: 'server',
-  prefetch: true,
+  prefetch: false,
   integrations: [react(), tailwind()],
 
   redirects: {
-    '/news': '/news/page/?page=1',
     '/home': '/',
     '/news/admin' : 'https://app.nocodb.com/#/nc/form/d6dc6d04-54a0-401e-a474-7228951f81f1',
-    '/documents': '/documents/page/?page=1',
-    '/documents/page/1': '/documents/page/?page=1',
     '/documents/admin': 'https://app.nocodb.com/#/nc/form/f34205b4-9dc1-4692-b68e-9d426f93a4f6',
-    '/events': '/events/page/?page=1',
     '/events/admin': 'https://app.nocodb.com/#/nc/form/3970ed65-4126-4333-b64d-28470c7c33dd',
   },
 

--- a/src/components/generalUtilities/Navigation.astro
+++ b/src/components/generalUtilities/Navigation.astro
@@ -19,9 +19,8 @@ const { isHeroPage = false } = Astro.props;
       class="flex w-full flex-col px-5 py-5 lg:py-2 items-center justify-evenly lg:px-0 lg:flex-row lg:justify-between lg:backdrop-blur-sm lg:h-fit"
     >
       <a
-        href='/home'
-        class={`hidden lg:block fuc-back-image self-start w-9 absolute top-7 right-7 lg:order-2 lg:top-0 lg:right-0 lg:relative lg:top-auto lg:left-auto lg:w-20 ${isHeroPage ? `pointer-events-none` : ''}`}
-        
+        href="/home"
+        class={`hidden lg:block fuc-back-image self-start w-9 absolute top-7 right-7 lg:order-2 lg:top-0 lg:right-0 lg:relative lg:top-auto lg:left-auto lg:w-20 ${isHeroPage ? `pointer-events-none` : ""}`}
       >
         <Image
           src={escudoUnsaac}
@@ -34,21 +33,24 @@ const { isHeroPage = false } = Astro.props;
       >
         <div class="relative">
           <a
-            href="/news"
+            data-astro-reload
+            href="/news/page/?page=1"
             class="after:w-full after:h-px after:bg-gray-100 after:absolute after:bottom-0 after:left-0 after:origin-center after:scale-0 after:hover:scale-100 after:transition-transform"
             >NOTICIAS</a
           >
         </div>
         <div class="relative">
           <a
-            href="/documents"
+            data-astro-reload
+            href="/documents/page/?page=1"
             class="after:w-full after:h-px after:bg-gray-100 after:absolute after:bottom-0 after:left-0 after:origin-center after:scale-0 after:hover:scale-100 after:transition-transform"
             >DOCUMENTOS</a
           >
         </div>
         <div class="relative">
           <a
-            href="/events"
+            data-astro-reload
+            href="/events/page/?page=1"
             class="after:w-full after:h-px after:bg-gray-100 after:absolute after:bottom-0 after:left-0 after:origin-center after:scale-0 after:hover:scale-100 after:transition-transform"
             >EVENTOS</a
           >
@@ -59,6 +61,7 @@ const { isHeroPage = false } = Astro.props;
       >
         <div class="relative">
           <a
+            data-astro-reload
             href="/members"
             class="after:w-full after:h-px after:bg-gray-100 after:absolute after:bottom-0 after:left-0 after:origin-center after:scale-0 after:hover:scale-100 after:transition-transform"
             >MIEMBROS</a
@@ -78,11 +81,13 @@ const { isHeroPage = false } = Astro.props;
   <Hamburguer />
 </nav>
 <script>
-  document.addEventListener('astro:page-load', () => {
+  document.addEventListener("astro:page-load", () => {
     const toggleNav = () => {
-      document.querySelector(".nav-links")?.classList.toggle("-translate-x-full");
+      document
+        .querySelector(".nav-links")
+        ?.classList.toggle("-translate-x-full");
     };
     const menu = document.querySelector(".hamburguer");
-    menu?.addEventListener("click", () => toggleNav()); 
-  })
+    menu?.addEventListener("click", () => toggleNav());
+  });
 </script>

--- a/src/components/generalUtilities/NavigationPagination.astro
+++ b/src/components/generalUtilities/NavigationPagination.astro
@@ -1,5 +1,4 @@
 ---
-import { navigate } from "astro:transitions/client";
 import type { pageInfo } from "@customTypes/common";
 
 const { pageInfoData, currentSection } = Astro.props as { pageInfoData: pageInfo, currentSection: string };

--- a/src/components/newsComponents/NewsPageContent.astro
+++ b/src/components/newsComponents/NewsPageContent.astro
@@ -19,7 +19,6 @@ try {
 } catch (error) {
   return Astro.redirect("/news/page/?page=1");
 }
-
 ---
 
 {pages && (pages as NewsItem[]).map((newsItem) => <NewsCard {...newsItem} />)}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,12 +6,10 @@ export const onRequest = defineMiddleware(async ({ request, locals, url }, next)
     const referer = request.headers.get('Referer');
     if (referer) {
       const refererUrl = new URL(referer);
-      const pathParts = refererUrl.pathname.split('/');
-      const section = pathParts[1] || 'home';
       const pageParam = refererUrl.searchParams.get('page') || '1';
       response.headers.set('Cache-Control', 'public, max-age=0');
       response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500');
-      response.headers.set('Netlify-vary', `path=${url.pathname}&section=${section}&page=${pageParam}`);
+      response.headers.set('Netlify-vary', `path=${url.pathname}&page=${pageParam}`);
     }
   }
   return response;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,10 +6,12 @@ export const onRequest = defineMiddleware(async ({ request, locals, url }, next)
     const referer = request.headers.get('Referer');
     if (referer) {
       const refererUrl = new URL(referer);
+      const pathParts = refererUrl.pathname.split('/');
+      const section = pathParts[1] || 'home';
       const pageParam = refererUrl.searchParams.get('page') || '1';
       response.headers.set('Cache-Control', 'public, max-age=0');
       response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500');
-      response.headers.set('Netlify-vary', `path=${url.pathname}&referer-page=${pageParam}`);
+      response.headers.set('Netlify-vary', `path=${url.pathname}&section=${section}&page=${pageParam}`);
     }
   }
   return response;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ export const onRequest = defineMiddleware(async ({ request, locals, url }, next)
       const pageParam = refererUrl.searchParams.get('page') || '1';
       response.headers.set('Cache-Control', 'public, max-age=0');
       response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500');
-      response.headers.set('Netlify-vary', `query=page&header=referer:${pageParam}`);
+      response.headers.set('Netlify-vary', `path=${url.pathname}&referer-page=${pageParam}`);
     }
   }
   return response;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { defineMiddleware } from "astro:middleware";
+
+export const onRequest = defineMiddleware(async ({ request, locals, url }, next) => {
+  const response = await next();
+  if (url.pathname.includes('_server-islands')) {
+    const referer = request.headers.get('Referer');
+    if (referer) {
+      const refererUrl = new URL(referer);
+      const pageParam = refererUrl.searchParams.get('page') || '1';
+      response.headers.set('Cache-Control', 'public, max-age=0');
+      response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500');
+      response.headers.set('Netlify-vary', `query=page&header=referer:${pageParam}`);
+    }
+  }
+  return response;
+});

--- a/src/pages/events/details/[detailsId].astro
+++ b/src/pages/events/details/[detailsId].astro
@@ -30,7 +30,7 @@ const height = Imagen[0].height;
 
 Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
 Astro.response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500')
-Astro.response.headers.set("netlify-cache-tag", detailsId);
+Astro.response.headers.set("Netlify-Vary", `section=events&id=${Id}`);
 ---
 
 <Layout title=`${Evento}`>

--- a/src/pages/events/page/index.astro
+++ b/src/pages/events/page/index.astro
@@ -1,7 +1,7 @@
 ---
 Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
 Astro.response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500')
-Astro.response.headers.set('Netlify-vary','query=page');
+Astro.response.headers.set('Netlify-vary','query=page&section=events');
 export const prerender = true;
 
 // components

--- a/src/pages/news/details/[detailsId].astro
+++ b/src/pages/news/details/[detailsId].astro
@@ -25,7 +25,7 @@ const ContenidoParsed = marked.parse(Contenido);
 
 Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
 Astro.response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500')
-Astro.response.headers.set("netlify-cache-tag", detailsId);
+Astro.response.headers.set("Netlify-Vary", `section=events&id=${Id}`);
 ---
 
 <Layout title=`${Noticia}`>

--- a/src/pages/news/page/index.astro
+++ b/src/pages/news/page/index.astro
@@ -1,7 +1,7 @@
 ---
 Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
 Astro.response.headers.set('Netlify-CDN-Cache-Control', 'public, durable, s-maxage=300, stale-while-revalidate=3500')
-Astro.response.headers.set('Netlify-vary','query=page');
+Astro.response.headers.set('Netlify-vary','query=page&section=news');
 export const prerender = true; 
 // components
 import Layout from "@layouts/Layout.astro";


### PR DESCRIPTION
This pull request includes several updates to the `astro.config.mjs` configuration, navigation components, and caching headers to improve the website's functionality and performance. The most important changes include modifying redirect paths, adding data attributes for page reloads, and updating cache control headers.

Configuration updates:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL9-L19): Changed `prefetch` from `true` to `false` and removed several redirect paths.

Navigation component updates:

* [`src/components/generalUtilities/Navigation.astro`](diffhunk://#diff-cad7f0b6353c8c7b94d98fd5c36611fa10b95fa85ca60c509e449a77d6e05659L37-R53): Added `data-astro-reload` attributes to several navigation links to ensure they reload the page, and updated the event listener for `astro:page-load` to use double quotes. [[1]](diffhunk://#diff-cad7f0b6353c8c7b94d98fd5c36611fa10b95fa85ca60c509e449a77d6e05659L37-R53) [[2]](diffhunk://#diff-cad7f0b6353c8c7b94d98fd5c36611fa10b95fa85ca60c509e449a77d6e05659L81-R92)

Cache control header updates:

* [`src/middleware.ts`](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R1-R16): Introduced a new middleware to set cache control headers based on the referer URL's `page` parameter.
* `src/pages/events/details/[detailsId].astro`, `src/pages/news/details/[detailsId].astro`: Changed `Netlify-Vary` headers to include `section` and `id` parameters instead of `netlify-cache-tag`. ([src/pages/events/details/[detailsId].astroL33-R33](diffhunk://#diff-03bf4fc37fb67359d744ec01dbb7c8e9cf850af2cf06b71ee464d4f021e2a2b7L33-R33), [src/pages/news/details/[detailsId].astroL28-R28](diffhunk://#diff-8ab27e1b6f36ff2cbc7c9bd361bb7b08e3c64249bad22d6112ec695a4b4a0c51L28-R28))
* `src/pages/events/page/index.astro`, `src/pages/news/page/index.astro`: Updated `Netlify-vary` headers to include `section` along with `query=page`. [[1]](diffhunk://#diff-09de178218936377acc0455f759edcb864983278c2aba4b55989ae0c9f97563bL4-R4) [[2]](diffhunk://#diff-6fbe9d3e500ab1ecaa049434b8719f6ae53128a9bada686308cb7b4454a9b5d6L4-R4)